### PR TITLE
🔧 turbo.json: env: []を削除してCI/CDビルドエラーを修正

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -7,11 +7,9 @@
       "outputs": [".next/**", "!.next/cache/**"]
     },
     "beatfolio#build": {
-      "env": [],
       "outputs": [".next/**", "!.next/cache/**", "dist/**"]
     },
     "api-server#build": {
-      "env": [],
       "outputs": [".next/**", "!.next/cache/**", "dist/**"]
     },
     "lint": {


### PR DESCRIPTION
## 問題
CI/CD（GitHub Actions）でapi-serverのビルドが失敗していた。
エラー: "DATABASE_URL is not defined" および Auth0関連の環境変数エラー

## 原因
turbo.jsonで`env: []`を明示的に設定していたことが原因。

Turborepoはモノレポ用のビルドツールで、CI/CDでは以下の流れで実行される:
  GitHub Actions → turbo run build → next build

`env: []`の設定は「このタスクは環境変数に依存しない」という宣言になり、
Turboが環境変数をフィルタリングして子プロセス（next build）に渡さなくなる。

ローカルでは.envファイルから環境変数が読み込まれるため問題なく動作するが、
CI/CD環境では.envがなく、workflow側で設定した環境変数がTurboでブロックされていた。

## 解決策
`env`フィールド自体を削除することで、Turboのデフォルト動作に戻し、
環境変数が自動的に子プロセスに渡されるようにした。

これにより今後新しい環境変数を追加しても、turbo.jsonの変更は不要になる。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores（その他）**
  * ビルド設定を最適化しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->