### PR TITLE
🐛 Storybookのモジュール解決エラーを修正

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5559,39 +5559,6 @@
         "storybook": "^8.6.15"
       }
     },
-    "node_modules/@storybook/addon-docs/node_modules/@storybook/csf-plugin": {
-      "version": "8.6.15",
-      "resolved": "https://registry.npmjs.org/@storybook/csf-plugin/-/csf-plugin-8.6.15.tgz",
-      "integrity": "sha512-ZLz/mtOoE1Jj2lE4pK3U7MmYrv5+lot3mGtwxGb832tcABMc97j9O+reCVxZYc7DeFbBuuEdMT9rBL/O3kXYmw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "unplugin": "^1.3.1"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/storybook"
-      },
-      "peerDependencies": {
-        "storybook": "^8.6.15"
-      }
-    },
-    "node_modules/@storybook/addon-docs/node_modules/@storybook/react-dom-shim": {
-      "version": "8.6.15",
-      "resolved": "https://registry.npmjs.org/@storybook/react-dom-shim/-/react-dom-shim-8.6.15.tgz",
-      "integrity": "sha512-m2trBmmd4iom1qwrp1F109zjRDc0cPaHYhDQxZR4Qqdz8pYevYJTlipDbH/K4NVB6Rn687RT29OoOPfJh6vkFA==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/storybook"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
-        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
-        "storybook": "^8.6.15"
-      }
-    },
     "node_modules/@storybook/addon-essentials": {
       "version": "8.6.15",
       "resolved": "https://registry.npmjs.org/@storybook/addon-essentials/-/addon-essentials-8.6.15.tgz",
@@ -5836,6 +5803,40 @@
         }
       }
     },
+    "node_modules/@storybook/builder-vite": {
+      "version": "8.6.15",
+      "resolved": "https://registry.npmjs.org/@storybook/builder-vite/-/builder-vite-8.6.15.tgz",
+      "integrity": "sha512-9Y05/ndZE6/eI7ZIUCD/QtH2htRIUs9j1gxE6oW0zRo9TJO1iqxfLNwgzd59KEkId7gdZxPei0l+LGTUGXYKRg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@storybook/csf-plugin": "8.6.15",
+        "browser-assert": "^1.2.1",
+        "ts-dedent": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "storybook": "^8.6.15",
+        "vite": "^4.0.0 || ^5.0.0 || ^6.0.0"
+      }
+    },
+    "node_modules/@storybook/components": {
+      "version": "8.6.15",
+      "resolved": "https://registry.npmjs.org/@storybook/components/-/components-8.6.15.tgz",
+      "integrity": "sha512-+9GVKXPEW8Kl9zvNSTm9+VrJtx/puMZiO7gxCML63nK4aTWJXHQr4t9YUoGammSBM3AV1JglsKm6dBgJEeCoiA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "storybook": "^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0"
+      }
+    },
     "node_modules/@storybook/core": {
       "version": "8.6.15",
       "resolved": "https://registry.npmjs.org/@storybook/core/-/core-8.6.15.tgz",
@@ -5868,20 +5869,6 @@
         }
       }
     },
-    "node_modules/@storybook/core/node_modules/@storybook/theming": {
-      "version": "8.6.15",
-      "resolved": "https://registry.npmjs.org/@storybook/theming/-/theming-8.6.15.tgz",
-      "integrity": "sha512-dAbL0XOekyT6XsF49R6Etj3WxQ/LpdJDIswUUeHgVJ6/yd2opZOGbPxnwA3zlmAh1c0tvpPyhSDXxSG79u8e4Q==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/storybook"
-      },
-      "peerDependencies": {
-        "storybook": "^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0"
-      }
-    },
     "node_modules/@storybook/core/node_modules/semver": {
       "version": "7.7.3",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
@@ -5893,6 +5880,23 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/@storybook/csf-plugin": {
+      "version": "8.6.15",
+      "resolved": "https://registry.npmjs.org/@storybook/csf-plugin/-/csf-plugin-8.6.15.tgz",
+      "integrity": "sha512-ZLz/mtOoE1Jj2lE4pK3U7MmYrv5+lot3mGtwxGb832tcABMc97j9O+reCVxZYc7DeFbBuuEdMT9rBL/O3kXYmw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "unplugin": "^1.3.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "storybook": "^8.6.15"
       }
     },
     "node_modules/@storybook/global": {
@@ -5914,6 +5918,138 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta"
+      }
+    },
+    "node_modules/@storybook/manager-api": {
+      "version": "8.6.15",
+      "resolved": "https://registry.npmjs.org/@storybook/manager-api/-/manager-api-8.6.15.tgz",
+      "integrity": "sha512-ZOFtH821vFcwzECbFYFTKtSVO96Cvwwg45dMh3M/9bZIdN7klsloX7YNKw8OKvwE6XLFLsi2OvsNNcmTW6g88w==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "storybook": "^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0"
+      }
+    },
+    "node_modules/@storybook/preview-api": {
+      "version": "8.6.15",
+      "resolved": "https://registry.npmjs.org/@storybook/preview-api/-/preview-api-8.6.15.tgz",
+      "integrity": "sha512-oqsp8f7QekB9RzpDqOXZQcPPRXXd/mTsnZSdAAQB/pBVqUpC9h/y5hgovbYnJ6DWXcpODbMwH+wbJHZu5lvm+w==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "storybook": "^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0"
+      }
+    },
+    "node_modules/@storybook/react": {
+      "version": "8.6.15",
+      "resolved": "https://registry.npmjs.org/@storybook/react/-/react-8.6.15.tgz",
+      "integrity": "sha512-hdnhlJg+YkpPMOw2hvK7+mhdxAbguA+TFTIAzVV9CeUYoHDIZAsgeKVhRmgZGN20NGjRN5ZcwkplAMJnF9v+6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@storybook/components": "8.6.15",
+        "@storybook/global": "^5.0.0",
+        "@storybook/manager-api": "8.6.15",
+        "@storybook/preview-api": "8.6.15",
+        "@storybook/react-dom-shim": "8.6.15",
+        "@storybook/theming": "8.6.15"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "@storybook/test": "8.6.15",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
+        "storybook": "^8.6.15",
+        "typescript": ">= 4.2.x"
+      },
+      "peerDependenciesMeta": {
+        "@storybook/test": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@storybook/react-dom-shim": {
+      "version": "8.6.15",
+      "resolved": "https://registry.npmjs.org/@storybook/react-dom-shim/-/react-dom-shim-8.6.15.tgz",
+      "integrity": "sha512-m2trBmmd4iom1qwrp1F109zjRDc0cPaHYhDQxZR4Qqdz8pYevYJTlipDbH/K4NVB6Rn687RT29OoOPfJh6vkFA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
+        "storybook": "^8.6.15"
+      }
+    },
+    "node_modules/@storybook/react-vite": {
+      "version": "8.6.15",
+      "resolved": "https://registry.npmjs.org/@storybook/react-vite/-/react-vite-8.6.15.tgz",
+      "integrity": "sha512-9st+2NCemzzBwmindpDrRLEqYJmwwd2RnXMoj+Wt4Y1r4MGoRe1l837ciT2tmstaqekY2mVUSYd6879NzeeMYw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@joshwooding/vite-plugin-react-docgen-typescript": "0.5.0",
+        "@rollup/pluginutils": "^5.0.2",
+        "@storybook/builder-vite": "8.6.15",
+        "@storybook/react": "8.6.15",
+        "find-up": "^5.0.0",
+        "magic-string": "^0.30.0",
+        "react-docgen": "^7.0.0",
+        "resolve": "^1.22.8",
+        "tsconfig-paths": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "@storybook/test": "8.6.15",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
+        "storybook": "^8.6.15",
+        "vite": "^4.0.0 || ^5.0.0 || ^6.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@storybook/test": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@storybook/theming": {
+      "version": "8.6.15",
+      "resolved": "https://registry.npmjs.org/@storybook/theming/-/theming-8.6.15.tgz",
+      "integrity": "sha512-dAbL0XOekyT6XsF49R6Etj3WxQ/LpdJDIswUUeHgVJ6/yd2opZOGbPxnwA3zlmAh1c0tvpPyhSDXxSG79u8e4Q==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "storybook": "^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0"
       }
     },
     "node_modules/@swc/helpers": {
@@ -15123,256 +15259,6 @@
       "license": "MIT",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      }
-    },
-    "packages/ui/node_modules/@storybook/builder-vite": {
-      "version": "8.6.15",
-      "resolved": "https://registry.npmjs.org/@storybook/builder-vite/-/builder-vite-8.6.15.tgz",
-      "integrity": "sha512-9Y05/ndZE6/eI7ZIUCD/QtH2htRIUs9j1gxE6oW0zRo9TJO1iqxfLNwgzd59KEkId7gdZxPei0l+LGTUGXYKRg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@storybook/csf-plugin": "8.6.15",
-        "browser-assert": "^1.2.1",
-        "ts-dedent": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/storybook"
-      },
-      "peerDependencies": {
-        "storybook": "^8.6.15",
-        "vite": "^4.0.0 || ^5.0.0 || ^6.0.0"
-      }
-    },
-    "packages/ui/node_modules/@storybook/components": {
-      "version": "8.6.15",
-      "resolved": "https://registry.npmjs.org/@storybook/components/-/components-8.6.15.tgz",
-      "integrity": "sha512-+9GVKXPEW8Kl9zvNSTm9+VrJtx/puMZiO7gxCML63nK4aTWJXHQr4t9YUoGammSBM3AV1JglsKm6dBgJEeCoiA==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/storybook"
-      },
-      "peerDependencies": {
-        "storybook": "^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0"
-      }
-    },
-    "packages/ui/node_modules/@storybook/csf-plugin": {
-      "version": "8.6.15",
-      "resolved": "https://registry.npmjs.org/@storybook/csf-plugin/-/csf-plugin-8.6.15.tgz",
-      "integrity": "sha512-ZLz/mtOoE1Jj2lE4pK3U7MmYrv5+lot3mGtwxGb832tcABMc97j9O+reCVxZYc7DeFbBuuEdMT9rBL/O3kXYmw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "unplugin": "^1.3.1"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/storybook"
-      },
-      "peerDependencies": {
-        "storybook": "^8.6.15"
-      }
-    },
-    "packages/ui/node_modules/@storybook/instrumenter": {
-      "version": "8.6.15",
-      "resolved": "https://registry.npmjs.org/@storybook/instrumenter/-/instrumenter-8.6.15.tgz",
-      "integrity": "sha512-TvHR/+yyIAOp/1bLulFai2kkhIBtAlBw7J6Jd9DKyInoGhTWNE1G1Y61jD5GWXX29AlwaHfzGUaX5NL1K+FJpg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@storybook/global": "^5.0.0",
-        "@vitest/utils": "^2.1.1"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/storybook"
-      },
-      "peerDependencies": {
-        "storybook": "^8.6.15"
-      }
-    },
-    "packages/ui/node_modules/@storybook/manager-api": {
-      "version": "8.6.15",
-      "resolved": "https://registry.npmjs.org/@storybook/manager-api/-/manager-api-8.6.15.tgz",
-      "integrity": "sha512-ZOFtH821vFcwzECbFYFTKtSVO96Cvwwg45dMh3M/9bZIdN7klsloX7YNKw8OKvwE6XLFLsi2OvsNNcmTW6g88w==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/storybook"
-      },
-      "peerDependencies": {
-        "storybook": "^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0"
-      }
-    },
-    "packages/ui/node_modules/@storybook/preview-api": {
-      "version": "8.6.15",
-      "resolved": "https://registry.npmjs.org/@storybook/preview-api/-/preview-api-8.6.15.tgz",
-      "integrity": "sha512-oqsp8f7QekB9RzpDqOXZQcPPRXXd/mTsnZSdAAQB/pBVqUpC9h/y5hgovbYnJ6DWXcpODbMwH+wbJHZu5lvm+w==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/storybook"
-      },
-      "peerDependencies": {
-        "storybook": "^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0"
-      }
-    },
-    "packages/ui/node_modules/@storybook/react": {
-      "version": "8.6.15",
-      "resolved": "https://registry.npmjs.org/@storybook/react/-/react-8.6.15.tgz",
-      "integrity": "sha512-hdnhlJg+YkpPMOw2hvK7+mhdxAbguA+TFTIAzVV9CeUYoHDIZAsgeKVhRmgZGN20NGjRN5ZcwkplAMJnF9v+6w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@storybook/components": "8.6.15",
-        "@storybook/global": "^5.0.0",
-        "@storybook/manager-api": "8.6.15",
-        "@storybook/preview-api": "8.6.15",
-        "@storybook/react-dom-shim": "8.6.15",
-        "@storybook/theming": "8.6.15"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/storybook"
-      },
-      "peerDependencies": {
-        "@storybook/test": "8.6.15",
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
-        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
-        "storybook": "^8.6.15",
-        "typescript": ">= 4.2.x"
-      },
-      "peerDependenciesMeta": {
-        "@storybook/test": {
-          "optional": true
-        },
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "packages/ui/node_modules/@storybook/react-dom-shim": {
-      "version": "8.6.15",
-      "resolved": "https://registry.npmjs.org/@storybook/react-dom-shim/-/react-dom-shim-8.6.15.tgz",
-      "integrity": "sha512-m2trBmmd4iom1qwrp1F109zjRDc0cPaHYhDQxZR4Qqdz8pYevYJTlipDbH/K4NVB6Rn687RT29OoOPfJh6vkFA==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/storybook"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
-        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
-        "storybook": "^8.6.15"
-      }
-    },
-    "packages/ui/node_modules/@storybook/react-vite": {
-      "version": "8.6.15",
-      "resolved": "https://registry.npmjs.org/@storybook/react-vite/-/react-vite-8.6.15.tgz",
-      "integrity": "sha512-9st+2NCemzzBwmindpDrRLEqYJmwwd2RnXMoj+Wt4Y1r4MGoRe1l837ciT2tmstaqekY2mVUSYd6879NzeeMYw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@joshwooding/vite-plugin-react-docgen-typescript": "0.5.0",
-        "@rollup/pluginutils": "^5.0.2",
-        "@storybook/builder-vite": "8.6.15",
-        "@storybook/react": "8.6.15",
-        "find-up": "^5.0.0",
-        "magic-string": "^0.30.0",
-        "react-docgen": "^7.0.0",
-        "resolve": "^1.22.8",
-        "tsconfig-paths": "^4.2.0"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/storybook"
-      },
-      "peerDependencies": {
-        "@storybook/test": "8.6.15",
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
-        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
-        "storybook": "^8.6.15",
-        "vite": "^4.0.0 || ^5.0.0 || ^6.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@storybook/test": {
-          "optional": true
-        }
-      }
-    },
-    "packages/ui/node_modules/@storybook/test": {
-      "version": "8.6.15",
-      "resolved": "https://registry.npmjs.org/@storybook/test/-/test-8.6.15.tgz",
-      "integrity": "sha512-EwquDRUDVvWcZds3T2abmB5wSN/Vattal4YtZ6fpBlIUqONV4o/cOBX39cFfQSUCBrIXIjQ6RmapQCHK/PvBYw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@storybook/global": "^5.0.0",
-        "@storybook/instrumenter": "8.6.15",
-        "@testing-library/dom": "10.4.0",
-        "@testing-library/jest-dom": "6.5.0",
-        "@testing-library/user-event": "14.5.2",
-        "@vitest/expect": "2.0.5",
-        "@vitest/spy": "2.0.5"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/storybook"
-      },
-      "peerDependencies": {
-        "storybook": "^8.6.15"
-      }
-    },
-    "packages/ui/node_modules/@storybook/theming": {
-      "version": "8.6.15",
-      "resolved": "https://registry.npmjs.org/@storybook/theming/-/theming-8.6.15.tgz",
-      "integrity": "sha512-dAbL0XOekyT6XsF49R6Etj3WxQ/LpdJDIswUUeHgVJ6/yd2opZOGbPxnwA3zlmAh1c0tvpPyhSDXxSG79u8e4Q==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/storybook"
-      },
-      "peerDependencies": {
-        "storybook": "^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0"
-      }
-    },
-    "packages/ui/node_modules/@testing-library/dom": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.0.tgz",
-      "integrity": "sha512-pemlzrSESWbdAloYml3bAJMEfNh1Z7EduzqPKprCH5S341frlpYnUEW0H72dLxa6IsYr+mPno20GiSm+h9dEdQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@babel/code-frame": "^7.10.4",
-        "@babel/runtime": "^7.12.5",
-        "@types/aria-query": "^5.0.1",
-        "aria-query": "5.3.0",
-        "chalk": "^4.1.0",
-        "dom-accessibility-api": "^0.5.9",
-        "lz-string": "^1.5.0",
-        "pretty-format": "^27.0.2"
-      },
-      "engines": {
-        "node": ">=18"
       }
     },
     "packages/ui/node_modules/doctrine": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -12,17 +12,17 @@
     "test:watch": "vitest --watch"
   },
   "dependencies": {
+    "@radix-ui/react-progress": "^1.1.0",
+    "@radix-ui/react-tabs": "^1.1.1",
     "@tailwindcss/postcss": "^4.0.15",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "justd-icons": "^1.10.25",
     "lucide-react": "^0.474.0",
+    "next-themes": "^0.4.6",
     "react-lazy-load-image-component": "^1.6.3",
     "tailwind-merge": "^2.6.0",
-    "tailwind-variants": "^1.0.0",
-    "@radix-ui/react-progress": "^1.1.0",
-    "@radix-ui/react-tabs": "^1.1.1",
-    "next-themes": "^0.4.6",
-    "justd-icons": "^1.10.25"
+    "tailwind-variants": "^1.0.0"
   },
   "peerDependencies": {
     "react": "^19.0.0",
@@ -34,15 +34,15 @@
     "@storybook/addon-links": "^8.6.15",
     "@storybook/react": "^8.6.15",
     "@storybook/react-vite": "^8.6.15",
+    "@types/react": "^19.0.12",
+    "@types/react-dom": "^19",
     "@types/react-lazy-load-image-component": "^1.6.4",
+    "eslint": "^8.57.1",
     "postcss": "^8.5.3",
     "storybook": "^8.6.15",
     "tailwindcss": "^4.0.15",
-    "vite": "^6.4.1",
-    "eslint": "^8.57.1",
     "typescript": "^5",
-    "@types/react": "^19.0.12",
-    "@types/react-dom": "^19"
+    "vite": "^6.4.1"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Summary

- npmワークスペースのホイスティング不整合により、`@storybook/react-vite` がルートの `node_modules` にホイストされず、Storybook起動時に `CriticalPresetLoadError` が発生していた問題を修正
- `packages/ui` の依存関係を再インストールし、ホイスティングを正常化

## 根本原因

`storybook` CLI本体はルートの `node_modules` にホイストされていたが、`@storybook/react-vite` は `packages/ui/node_modules` に隔離されていた。CLI実行時のNode.jsの `require` チェーンがルートから始まるため、ローカルにしかないパッケージを解決できなかった。

```
node_modules/
  storybook/              ← ルートにホイスト済み（CLIはここから実行）
  @storybook/core/        ← ルートにホイスト済み
  @storybook/react-vite/  ← ❌ ルートに存在せず（packages/ui/node_modulesに隔離）
```

## 対応内容

`npm install -w packages/ui` で依存関係を再インストールし、`@storybook/react-vite` がルートにホイストされるよう解決。

## Test plan

- [ ] `npm run storybook -w packages/ui` でStorybook が正常に起動すること
- [ ] 既存のコンポーネントストーリーが表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **その他**
  * UIコンポーネント関連のライブラリとツールの依存関係を更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->