### PR TITLE
chore(ui): Storybook MCP を導入し Claude Code から spec を参照可能に

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,8 @@ yarn-error.log*
 next-env.d.ts
 
 *storybook.log
+
+# claude code (個人設定 / 実行時状態はコミットしない、.mcp.json は共有する)
+.claude/settings.local.json
+.claude/scheduled_tasks.lock
+.claude/projects/

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "storybook": {
+      "type": "http",
+      "url": "http://localhost:6006/mcp"
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -15641,7 +15641,7 @@
         "@types/react-dom": "^19",
         "@types/react-lazy-load-image-component": "^1.6.4",
         "eslint": "^8.57.1",
-        "eslint-plugin-storybook": "10.3.6",
+        "eslint-plugin-storybook": "^10.3.6",
         "postcss": "^8.5.3",
         "storybook": "^10.3.6",
         "tailwindcss": "^4.0.15",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5767,12 +5767,32 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@storybook/global": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/@storybook/global/-/global-5.0.0.tgz",
       "integrity": "sha512-FcOqPAXACP0I3oJ/ws6/rrPT9WGhu915Cg8D02a9YxLo0DE9zI+a9A5gRGvmQ09fiWPukqI8ZAEoQEdWUKMQdQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@storybook/mcp": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@storybook/mcp/-/mcp-0.7.0.tgz",
+      "integrity": "sha512-Pr4E61tM5e7aDzqgNOL/Ylw8CGdb+BIDGOf3vbmFfkR8ZnXjPxaV/vhTEsiXynnIpjQWCzySCxOU1icxZsgjrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tmcp/adapter-valibot": "^0.1.5",
+        "@tmcp/transport-http": "^0.8.5",
+        "tmcp": "^1.19.3",
+        "valibot": "1.2.0"
+      }
     },
     "node_modules/@swc/helpers": {
       "version": "0.5.15",
@@ -6115,6 +6135,74 @@
           "optional": true
         },
         "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@tmcp/adapter-valibot": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/@tmcp/adapter-valibot/-/adapter-valibot-0.1.5.tgz",
+      "integrity": "sha512-9P2wrVYPngemNK0UvPb/opC722/jfd09QxXmme1TRp/wPsl98vpSk/MXt24BCMqBRv4Dvs0xxJH4KHDcjXW52Q==",
+      "dev": true,
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@valibot/to-json-schema": "^1.3.0",
+        "valibot": "^1.1.0"
+      },
+      "peerDependencies": {
+        "tmcp": "^1.17.0",
+        "valibot": "^1.1.0"
+      }
+    },
+    "node_modules/@tmcp/adapter-valibot/node_modules/@valibot/to-json-schema": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@valibot/to-json-schema/-/to-json-schema-1.6.0.tgz",
+      "integrity": "sha512-d6rYyK5KVa2XdqamWgZ4/Nr+cXhxjy7lmpe6Iajw15J/jmU+gyxl2IEd1Otg1d7Rl3gOQL5reulnSypzBtYy1A==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "valibot": "^1.3.0"
+      }
+    },
+    "node_modules/@tmcp/adapter-valibot/node_modules/valibot": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/valibot/-/valibot-1.3.1.tgz",
+      "integrity": "sha512-sfdRir/QFM0JaF22hqTroPc5xy4DimuGQVKFrzF1YfGwaS1nJot3Y8VqMdLO2Lg27fMzat2yD3pY5PbAYO39Gg==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "typescript": ">=5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@tmcp/session-manager": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@tmcp/session-manager/-/session-manager-0.2.1.tgz",
+      "integrity": "sha512-DOGy9LfufXCy1wfpGHZ6qPSDQtRnTVwOb71+41ffovTqzLMZlK3iLK/LIsekHxIiku+iIAUiqEKN+DHbqEm8IA==",
+      "dev": true,
+      "peerDependencies": {
+        "tmcp": "^1.16.3"
+      }
+    },
+    "node_modules/@tmcp/transport-http": {
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/@tmcp/transport-http/-/transport-http-0.8.5.tgz",
+      "integrity": "sha512-qQLqiCTtbxtTSswqOn/782df7O57RxI/yLUtCDQ++kHEhbmDUc8glmmtGJ3mrb7yPSPoM5VF2Pc2Q5cA6quzLA==",
+      "dev": true,
+      "dependencies": {
+        "@tmcp/session-manager": "^0.2.1",
+        "esm-env": "^1.2.2"
+      },
+      "peerDependencies": {
+        "@tmcp/auth": "^0.3.3 || ^0.4.0",
+        "tmcp": "^1.18.0"
+      },
+      "peerDependenciesMeta": {
+        "@tmcp/auth": {
           "optional": true
         }
       }
@@ -9212,6 +9300,13 @@
         "url": "https://eslint.org/donate"
       }
     },
+    "node_modules/esm-env": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/esm-env/-/esm-env-1.2.2.tgz",
+      "integrity": "sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/espree": {
       "version": "10.4.0",
       "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
@@ -10744,6 +10839,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-rpc-2.0": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/json-rpc-2.0/-/json-rpc-2.0-1.7.1.tgz",
+      "integrity": "sha512-JqZjhjAanbpkXIzFE7u8mE/iFblawwlXtONaCvRqI+pyABVz7B4M1EUNpyVW+dZjqgQ2L5HFmZCmOCgUKm00hg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -11926,6 +12028,13 @@
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
       }
+    },
+    "node_modules/picoquery": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/picoquery/-/picoquery-2.5.0.tgz",
+      "integrity": "sha512-j1kgOFxtaCyoFCkpoYG2Oj3OdGakadO7HZ7o5CqyRazlmBekKhbDoUnNnXASE07xSY4nDImWZkrZv7toSxMi/g==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",
@@ -13129,6 +13238,13 @@
         "source-map": "^0.6.0"
       }
     },
+    "node_modules/sqids": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/sqids/-/sqids-0.3.0.tgz",
+      "integrity": "sha512-lOQK1ucVg+W6n3FhRwwSeUijxe93b51Bfz5PMRMihVf1iVkl82ePQG7V5vwrhzB11v0NtsR25PSZRGiSomJaJw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/stable-hash": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/stable-hash/-/stable-hash-0.0.5.tgz",
@@ -13643,6 +13759,20 @@
       "integrity": "sha512-XHhPmHxphLi+LGbH0G/O7dmUH9V65OY20R7vH8gETHsp5AZCjBk9l8sqmRKLaGOxnETU7XNSDUPtewAy/K6jbA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/tmcp": {
+      "version": "1.19.3",
+      "resolved": "https://registry.npmjs.org/tmcp/-/tmcp-1.19.3.tgz",
+      "integrity": "sha512-plz/TLKNFrdfQN32LjCTN6ULy6pynfGPgHcU7KGCI5dBrxQ9Mub99SmcYuzxEkLjJooQuOD3gosSwZEl1htOtw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "json-rpc-2.0": "^1.7.1",
+        "sqids": "^0.3.0",
+        "uri-template-matcher": "^1.1.1",
+        "valibot": "^1.1.0"
+      }
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
@@ -14600,6 +14730,13 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/uri-template-matcher": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/uri-template-matcher/-/uri-template-matcher-1.1.2.tgz",
+      "integrity": "sha512-uZc1h12jdO3m/R77SfTEOuo6VbMhgWznaawKpBjRGSJb7i91x5PgI37NQJtG+Cerxkk0yr1pylBY2qG1kQ+aEQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/use-callback-ref": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.3.tgz",
@@ -14650,6 +14787,21 @@
       "license": "MIT",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/valibot": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/valibot/-/valibot-1.2.0.tgz",
+      "integrity": "sha512-mm1rxUsmOxzrwnX5arGS+U4T25RdvpPjPN4yR0u9pUBov9+zGVtO84tif1eY4r6zWxVxu3KzIyknJy3rxfRZZg==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "typescript": ">=5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/victory-vendor": {
@@ -15482,6 +15634,7 @@
       "devDependencies": {
         "@storybook/addon-docs": "^10.3.6",
         "@storybook/addon-links": "^10.3.6",
+        "@storybook/addon-mcp": "^0.6.0",
         "@storybook/react": "^10.3.6",
         "@storybook/react-vite": "^10.3.6",
         "@types/react": "^19.0.12",
@@ -15626,6 +15779,30 @@
       },
       "peerDependenciesMeta": {
         "react": {
+          "optional": true
+        }
+      }
+    },
+    "packages/ui/node_modules/@storybook/addon-mcp": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-mcp/-/addon-mcp-0.6.0.tgz",
+      "integrity": "sha512-E79m2S7ik9wiF1AnI49fwbLQkrD03PicIZpCdeFhbbB19MF4tKFKyaQtbT3f6eaAP4EP2+COLDVLCQ7B3rGF4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@storybook/mcp": "0.7.0",
+        "@tmcp/adapter-valibot": "^0.1.5",
+        "@tmcp/transport-http": "^0.8.5",
+        "picoquery": "^2.5.0",
+        "tmcp": "^1.19.3",
+        "valibot": "1.2.0"
+      },
+      "peerDependencies": {
+        "@storybook/addon-vitest": "^0.0.0-0 || ^9.1.16 || ^10.0.0 || ^10.1.0-0 || ^10.2.0-0 || ^10.3.0-0 || ^10.4.0-0",
+        "storybook": "^0.0.0-0 || ^9.1.16 || ^10.0.0 || ^10.1.0-0 || ^10.2.0-0 || ^10.3.0-0 || ^10.4.0-0"
+      },
+      "peerDependenciesMeta": {
+        "@storybook/addon-vitest": {
           "optional": true
         }
       }

--- a/packages/ui/.storybook/main.ts
+++ b/packages/ui/.storybook/main.ts
@@ -9,6 +9,7 @@ const config: StorybookConfig = {
   addons: [
     getAbsolutePath("@storybook/addon-links"),
     getAbsolutePath("@storybook/addon-docs"),
+    getAbsolutePath("@storybook/addon-mcp"),
   ],
 
   framework: {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -34,20 +34,21 @@
     "react-dom": "^19.0.0"
   },
   "devDependencies": {
+    "@storybook/addon-docs": "^10.3.6",
     "@storybook/addon-links": "^10.3.6",
+    "@storybook/addon-mcp": "^0.6.0",
     "@storybook/react": "^10.3.6",
     "@storybook/react-vite": "^10.3.6",
     "@types/react": "^19.0.12",
     "@types/react-dom": "^19",
     "@types/react-lazy-load-image-component": "^1.6.4",
     "eslint": "^8.57.1",
+    "eslint-plugin-storybook": "10.3.6",
     "postcss": "^8.5.3",
     "storybook": "^10.3.6",
     "tailwindcss": "^4.0.15",
     "typescript": "^5",
-    "vite": "^6.4.1",
-    "eslint-plugin-storybook": "10.3.6",
-    "@storybook/addon-docs": "^10.3.6"
+    "vite": "^6.4.1"
   },
   "keywords": [],
   "author": "",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -43,7 +43,7 @@
     "@types/react-dom": "^19",
     "@types/react-lazy-load-image-component": "^1.6.4",
     "eslint": "^8.57.1",
-    "eslint-plugin-storybook": "10.3.6",
+    "eslint-plugin-storybook": "^10.3.6",
     "postcss": "^8.5.3",
     "storybook": "^10.3.6",
     "tailwindcss": "^4.0.15",


### PR DESCRIPTION
## Summary
- `@storybook/addon-mcp@^0.6.0` を `packages/ui` に追加し、Storybook dev server (`http://localhost:6006/mcp`) を MCP サーバーとして公開
- チーム共有設定 `.mcp.json` をリポジトリ直下に配置（Claude Code がプロジェクトスコープで自動検出）
- 個人有効化設定 `.claude/settings.local.json` は gitignore 済み（`enabledMcpjsonServers: ["storybook"]` を初期値として配布想定）
- `.gitignore` に Claude Code の個人/実行時ファイル（`settings.local.json` / `scheduled_tasks.lock` / `projects/`）を追加

## 利用できる MCP ツール（5種）
Storybook dev 起動中、Claude Code から以下が呼び出せる:
- `list-all-documentation` — 全コンポーネント/Story を構造化 JSON で列挙
- `get-documentation` — 指定コンポーネントの props / story / コードスニペットを取得
- `get-documentation-for-story` — 特定 Story バリアントの詳細
- `preview-stories` — Story のプレビュー URL を返す
- `get-storybook-story-instructions` — Story 作成・修正時のフレームワーク別ガイドラインを取得

> `run-story-tests` は optional peer の `@storybook/addon-vitest` 未導入のため非搭載（必要なら別 PR で追加検討）

## 動作確認
- `npm run storybook -w ui` で `:6006` 起動を確認
- `POST /mcp` initialize → 200, `serverInfo: @storybook/addon-mcp@0.6.0`
- `tools/list` で上記5ツールの応答確認
- pre-commit (lint-staged + prettier) パス

## 利用方法（チームメンバー向け）
1. `git pull` 後、新しい Claude Code セッションを起動すると `.mcp.json` を自動検出
2. 初回はサーバー承認プロンプトが出るので、承認するか個人設定 `.claude/settings.local.json` に下記を追記:
   ```json
   { "enabledMcpjsonServers": ["storybook"] }
   ```
3. 別ターミナルで `npm run storybook -w ui` を起動した状態でエージェントに依頼すると、Storybook を spec として参照しながら作業できる

## Test plan
- [ ] reviewer 環境で `git pull` → Claude Code 再起動 → `.mcp.json` が読み込まれること
- [ ] `npm run storybook -w ui` 起動中に Claude Code から MCP ツールが応答すること
- [ ] `npm run build-storybook -w ui` が引き続き成功すること
- [ ] `.claude/settings.local.json` が gitignore で無視されることを `git check-ignore` で確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Storybook開発環境の設定を更新し、MCP連携機能を追加しました。開発用依存関係を整理し、ローカルの状態ファイルを適切に管理するための設定ルールを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->